### PR TITLE
Fix command option type values being compared to enum instances

### DIFF
--- a/src/Models/Interactions/ApplicationCommandDataOption.php
+++ b/src/Models/Interactions/ApplicationCommandDataOption.php
@@ -107,13 +107,13 @@ final class ApplicationCommandDataOption implements BinarySerializable{
         $stream->putString($this->name);
         $stream->putByte($this->type->value);
         $stream->putBool($this->value !== null);
-        if(is_string($this->value) && $this->type->value === CommandOptionType::STRING){
+        if(is_string($this->value) && $this->type->value === CommandOptionType::STRING->value){
             $stream->putString($this->value);
-        }elseif(is_int($this->value) && $this->type->value === CommandOptionType::INTEGER){
+        }elseif(is_int($this->value) && $this->type->value === CommandOptionType::INTEGER->value){
             $stream->putLong($this->value);
-        }elseif(is_float($this->value) && $this->type->value === CommandOptionType::NUMBER){
+        }elseif(is_float($this->value) && $this->type->value === CommandOptionType::NUMBER->value){
             $stream->putDouble($this->value);
-        }elseif(is_bool($this->value) && $this->type->value === CommandOptionType::BOOLEAN){
+        }elseif(is_bool($this->value) && $this->type->value === CommandOptionType::BOOLEAN->value){
             $stream->putBool($this->value);
         }elseif($this->value !== null){
             throw new \AssertionError("Invalid value type for option type {$this->type->value}");


### PR DESCRIPTION
This PR fixes #126. After some digging I found the core issue that led to the silent termination of the thread. The thread gets terminated because in the `binarySerialize()` function located in `ApplicationCommandDataOption.php`, we are comparing INT values (`type->value`) with enum instances. 

e.g `$this->type->value === CommandOptionType::STRING` basically translates to `3 === enum(JaxkDev\DiscordBot\Models\Interactions\Commands\CommandOptionType::STRING)`

This can be fixed by using the `value` property given to us.  `$this->type->value === CommandOptionType::STRING->value` now translates to `3 === 3` and works as intended.

If there are any changes you would like me to make, please do request!

(test)
https://github.com/DiscordBot-PMMP/DiscordBot/assets/36070804/c650b1b8-1d83-4615-96cc-78b402761ad9